### PR TITLE
Add /charging/api/health endpoint that pings MongoDB

### DIFF
--- a/src/wstore/admin/views.py
+++ b/src/wstore/admin/views.py
@@ -27,6 +27,7 @@ from logging import getLogger
 
 from django.conf import settings
 
+from wstore.store_commons.database import get_database_connection
 from wstore.store_commons.resource import Resource
 from wstore.store_commons.utils.http import JsonResponse, authentication_required, build_response, supported_request_mime_types
 from wstore.store_commons.utils.units import ChargePeriod, CurrencyCode
@@ -47,6 +48,18 @@ class ChargePeriodCollection(Resource):
 class CurrencyCodeCollection(Resource):
     def read(self, request):
         return JsonResponse(200, CurrencyCode.to_json())
+
+
+class HealthCollection(Resource):
+    def read(self, request):
+        try:
+            db = get_database_connection()
+            db.command("ping")
+        except Exception as e:
+            logger.error(f"Health check failed: {e}")
+            return build_response(request, 503, "database unavailable")
+
+        return JsonResponse(200, {"status": "ok"})
 
 
 class NotificationConfigCollection(Resource):

--- a/src/wstore/urls.py
+++ b/src/wstore/urls.py
@@ -87,6 +87,10 @@ urlpatterns = [
         admin_views.CurrencyCodeCollection(permitted_methods=("GET",)),
     ),
     url(
+        r"^charging/api/health/?$",
+        admin_views.HealthCollection(permitted_methods=("GET",)),
+    ),
+    url(
         r"^charging/api/orderManagement/orders/?$",
         ordering_views.OrderingCollection(permitted_methods=("POST",)),
     ),


### PR DESCRIPTION
## Summary
  - Adds a new `GET /charging/api/health` endpoint that returns 200 if MongoDB responds to a `ping`, or 503 otherwise.
  - The current `/charging/api/assetManagement/currencyCodes` used as readiness/liveness probe is purely static (`CurrencyCode.to_json()` reads a hardcoded
  list from settings) and does not detect MongoDB connectivity issues.
  - Observed in production: after an ArgoCD sync regenerated the MongoDB Secret (`randAlphaNum 30` in the chart template), the running pod kept passing probes
   despite all DB-touching requests failing with `pymongo.errors.OperationFailure: Authentication failed`. Restarting the pod was the only fix.